### PR TITLE
fix: add force flag to git add

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ echo "== [2/4] …checking for issues present in the codebase before your pull r
 echo
 bento init &> /dev/null
 bento archive --all
-git add .bento*
+git add -f .bento*
 
 echo
 echo "== [3/4] …now adding your pull request's changes back…"


### PR DESCRIPTION
The github action was adding the archive file but this failed
if .bento was in the project's gitignore.

This adds a force flag to the git add step