### PR TITLE
.github: Run r2c.registry.latest via Bento Action

### DIFF
--- a/.bento/config.yml
+++ b/.bento/config.yml
@@ -14,6 +14,9 @@ tools:
     - DL3027
     - DL4001
     run: true
+  r2c.registry.latest:
+    ignore: []
+    run: true
   shellcheck:
     ignore:
     - SC1004


### PR DESCRIPTION
This commit:

 - Adds the Bento Action as a new workflow if needed

 - Sets up Slack notifications on failure

 - Enables the r2c.registry.latest tool in the Bento config

Relates to https://github.com/returntocorp/enterprise/issues/19
